### PR TITLE
fix: afk alias for newer macOS versions

### DIFF
--- a/shell/.aliases
+++ b/shell/.aliases
@@ -12,7 +12,7 @@ alias ls='gls --color -h --group-directories-first -F'
 alias cat='bat --paging never --decorations never --plain'
 
 # Lock the screen (when going AFK)
-alias afk='/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend'
+alias afk='pmset displaysleepnow'
 
 # Copy public key to clipboard:
 alias pubkey="cat ~/.ssh/id_rsa.pub | pbcopy | echo '=> Public key copied to pasteboard.'"


### PR DESCRIPTION
fix: #154 

I've fixed this taking reference to the answer in apple stack exchange discussion: https://apple.stackexchange.com/a/434795
which states that 
> it achieves somewhat similar behaviour to what CGSession -suspend did